### PR TITLE
Make grillbiff identifier less specific

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -12,7 +12,7 @@ use \Symfony\Component\DomCrawler\Crawler;
 
 class Grillbiffen
 {
-    const GRILLBIFF_IDENTIFIER = 'Grillbiff med';
+    const GRILLBIFF_IDENTIFIER = 'Grillbiff';
 
     protected $swedishDays = [
         'Måndag',


### PR DESCRIPTION
Sometimes the returned data is misspelled or formatted, make the
identifier less specific to improve matching.

Issue #5 