### PR TITLE
run composer validate with --no-check-publish

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Validate composer.json and composer.lock
-      run: composer validate
+      run: composer validate --no-check-publish
 
     - name: Cache Composer packages
       id: composer-cache


### PR DESCRIPTION
This skips check if composer.json is suitable for publishing as a package on Packagist